### PR TITLE
Add some smoke tests with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+---
+language: python
+
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+
+services:
+  - mongodb
+
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
+
+script:
+  - PYTHONPATH=. py.test -vv --cov-report term-missing --cov .
+
+after_success:
+    - coveralls

--- a/README.md
+++ b/README.md
@@ -136,3 +136,19 @@ Feature Requests
 About
 ============
 This is a project I worked on a few years ago, but shelved it as I wasn't happy with my append/pop item implementation. I have decided to ditch that support altogether and release as is for now to get a starting base. Some code had to be re-written/worked around due to newer versions of pymongo (original conitedb was developed on Ubuntu LTS 12.04!).
+
+Testing
+=========
+
+Automated testing is provided by http://travis-ci.org configured by the .travis.yml.
+The test runner is powered by py.test.
+Coverage is provided by http://coveralls.io
+
+Running the tests
+
+```
+  docker run -dP -p 27017:27017 mongo
+  pip install -r requirements.txt
+  pip install -r requirements-dev.txt
+  PYTHONPATH=. py.test -vv --cov-report term-missing --cov=.
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pymongo

--- a/tests/test_conitedb.py
+++ b/tests/test_conitedb.py
@@ -1,0 +1,23 @@
+import ConiteDB
+import pytest
+
+
+def test_db_connection_ok():
+    """ Basic test to make sure we can connect to mongodb """
+    c = ConiteDB.ConiteDB()
+    server_info = c.conn.server_info()
+    assert server_info['ok'] == 1.0
+
+
+@pytest.mark.parametrize("cinames,updates", [
+    (["test_conitedb_add"], {'foo': 'bar'})
+])
+def test_conitedb_add(cinames, updates):
+    """ Adds should always work! """
+    c = ConiteDB.ConiteDB()
+    c.add(cinames, updates)
+    results = c.desc(cinames)
+    for ciname in cinames:
+        assert ciname in results
+        for update_key, update_value in updates.items():
+            assert results.get(ciname, {}).get(update_key) == update_value


### PR DESCRIPTION
Examples:
- Running tests on travis-ci.org - https://travis-ci.org/daniellawrence/ConiteDB
- Tracking test coverage on coveralls.org - https://coveralls.io/builds/7098569

You will need to login (via github) to both to enable for this project... if you choose to merge it.
